### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/watchiot/watchiot-repo-notif.png?label=ready&title=Ready)](https://waffle.io/watchiot/watchiot-repo-notif)
 [![Build Status](https://travis-ci.org/watchiot/watchiot-repo-notif.svg?branch=master)](https://travis-ci.org/watchiot/watchiot-repo-notif)
 
 # Watchiot Repository of Notifications


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/watchiot/watchiot-repo-notif

This was requested by a real person (user gorums) on waffle.io, we're not trying to spam you.